### PR TITLE
Allow users to specify imagePullSecrets

### DIFF
--- a/charts/snappydata/README.md
+++ b/charts/snappydata/README.md
@@ -224,6 +224,7 @@ The following table lists the configuration parameters available for this chart
 | `image` |  Docker repo from which the SnappyData Docker image will be pulled    |  `snappydatainc/snappydata`   |
 | `imageTag` |  Tag of the SnappyData Docker image to be pulled |   |
 | `imagePullPolicy` | Pull policy for the image.  | `IfNotPresent` |
+| `imagePullSecrets` | Secret name to be used to pull image from a private registry | |
 | `locators.conf` | List of configuration options to be passed to locators | |
 | `locators.resources` | Resource configuration for the locator Pods. User can configure CPU/memory requests and limits using this | `locators.requests.memory` is set to 1024Mi |
 | `locators.persistence.storageClass` | Storage class to be used while dynamically provisioning a volume | Default value is not defined so `default` storage class for the cluster will be chosen  |

--- a/charts/snappydata/templates/leader_statefulset.yaml
+++ b/charts/snappydata/templates/leader_statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - name: "{{ .Release.Name }}-leader"
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/snappydata/templates/locator_statefulset.yaml
+++ b/charts/snappydata/templates/locator_statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - name: "{{ .Release.Name }}-locator"
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/snappydata/templates/server_statefulset.yaml
+++ b/charts/snappydata/templates/server_statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - name: "{{ .Release.Name }}-server"
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/charts/snappydata/values.yaml
+++ b/charts/snappydata/values.yaml
@@ -4,6 +4,9 @@
 image: snappydatainc/snappydata
 imageTag: 1.0.2.1
 imagePullPolicy: IfNotPresent
+# Use "imagePullSecrets" to specify the secret name to be used while pulling image from a private registry
+# Replace "secretname" with the actual name of the secret
+#imagePullSecrets: secretname
 
 locators:
   ## config options for locators


### PR DESCRIPTION
Allow users to specify imagePullSecrets (secret name to be used while pulling image from a private registry)